### PR TITLE
Update test project dependencies to latest versions

### DIFF
--- a/test/janono.ado.testcase.associate.unittests/janono.ado.testcase.associate.unittests.csproj
+++ b/test/janono.ado.testcase.associate.unittests/janono.ado.testcase.associate.unittests.csproj
@@ -8,10 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to the package references in the `test/janono.ado.testcase.associate.unittests/janono.ado.testcase.associate.unittests.csproj` file to ensure compatibility with newer versions and improve the build process.

Package updates:

* Updated `Microsoft.NET.Test.Sdk` from version `16.9.4` to `17.12.0`.
* Updated `MSTest.TestAdapter` from version `2.2.3` to `3.6.3`.
* Updated `MSTest.TestFramework` from version `2.2.3` to `3.6.3`.
* Updated `coverlet.collector` from version `3.0.2` to `6.0.2` and added `IncludeAssets` and `PrivateAssets` tags to specify asset types and visibility.